### PR TITLE
Add LSB tags and overrides for Debian

### DIFF
--- a/templates/debian/x11vnc.erb
+++ b/templates/debian/x11vnc.erb
@@ -3,13 +3,13 @@
 # THIS FILE IS MANAGED BY PUPPET, CHANGES WILL BE OVERWRITTEN WITHOUT FURTHER NOTICE
 
 ### BEGIN INIT INFO
-# Provides:          x11vnc
+# Provides:          <%= @service %>
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start/stop custom VNC
-# Description:       Service x11vnc
+# Description:       Service <%= @service %>
 ### END INIT INFO
 
 . /lib/lsb/init-functions

--- a/templates/debian/x11vnc.erb
+++ b/templates/debian/x11vnc.erb
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+# THIS FILE IS MANAGED BY PUPPET, CHANGES WILL BE OVERWRITTEN WITHOUT FURTHER NOTICE
+
+### BEGIN INIT INFO
+# Provides:          x11vnc
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop custom VNC
+# Description:       Service x11vnc
+### END INIT INFO
+
 . /lib/lsb/init-functions
 
 DISPLAY=:<%= @display %>

--- a/templates/debian/xvfb.erb
+++ b/templates/debian/xvfb.erb
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+# THIS FILE IS MANAGED BY PUPPET, CHANGES WILL BE OVERWRITTEN WITHOUT FURTHER NOTICE
+
+### BEGIN INIT INFO
+# Provides:          xvfb
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop custom Xvfb
+# Description:       Service xvfb
+### END INIT INFO
+
 . /lib/lsb/init-functions
 
 DISPLAY=:<%= @display %>

--- a/templates/debian/xvfb.erb
+++ b/templates/debian/xvfb.erb
@@ -3,13 +3,13 @@
 # THIS FILE IS MANAGED BY PUPPET, CHANGES WILL BE OVERWRITTEN WITHOUT FURTHER NOTICE
 
 ### BEGIN INIT INFO
-# Provides:          xvfb
+# Provides:          <%= @service %>
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start/stop custom Xvfb
-# Description:       Service xvfb
+# Description:       Service <%= @service %>
 ### END INIT INFO
 
 . /lib/lsb/init-functions


### PR DESCRIPTION
Hi,

on a stock Debian Wheezy this module is generating warnings:
 insserv: warning: script 'xvfb' missing LSB tags and overrides
 insserv: warning: script 'x11vnc' missing LSB tags and overrides

The patch corrects this.
Greetz,
Andre