### PR TITLE
Fix compilation catalog of puppet 4.10.9.

### DIFF
--- a/manifests/x11vnc.pp
+++ b/manifests/x11vnc.pp
@@ -75,7 +75,7 @@ class display::x11vnc (
       refreshonly => true,
       path   => $::path,
     } ~>
-    Service ['x11vnc']
+    Service['x11vnc']
   }
 
   service { 'x11vnc':

--- a/manifests/xvfb.pp
+++ b/manifests/xvfb.pp
@@ -92,7 +92,7 @@ class display::xvfb (
       refreshonly => true,
       path   => $::path,
     } ~>
-    Service ['xvfb']
+    Service['xvfb']
   }
 
   service { 'xvfb':


### PR DESCRIPTION
Puppet version:
```
# puppet -V
4.10.9
```
Fix error:
```
Info: Using configured environment 'pilot'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: No title provided and "Service[]" is not a valid resource reference on node spy.srv.ams3.city-srv.ru
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```