### PR TITLE
Fix run on Puppet 5.5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,25 +132,25 @@ class display (
   }
 
   class { 'display::xvfb':
-    display     => $display,
-    width       => $width,
-    height      => $height,
-    color       => $color,
-    runuser     => $runuser,
-    fbdir       => $fbdir,
-    package     => $xvfb_package,
-    service     => $xvfb_service,
-    xvfb_bin    => $xvfb_bin,
-    custom_args => $xvfb_custom_args,
+    display         => $display,
+    width           => $width,
+    height          => $height,
+    color           => $color,
+    runuser         => $runuser,
+    fbdir           => $fbdir,
+    package         => $xvfb_package,
+    service         => $xvfb_service,
+    xvfb_bin        => $xvfb_bin,
+    custom_args     => $xvfb_custom_args,
     refresh_systemd => $refresh_systemd,
   }
 
   class { 'display::x11vnc':
-    display     => $display,
-    x11vnc_bin  => $x11vnc_bin,
-    package     => $x11vnc_package,
-    service     => $x11vnc_service,
-    custom_args => $x11vnc_custom_args,
+    display         => $display,
+    x11vnc_bin      => $x11vnc_bin,
+    package         => $x11vnc_package,
+    service         => $x11vnc_service,
+    custom_args     => $x11vnc_custom_args,
     refresh_systemd => $refresh_systemd,
   }
 

--- a/manifests/x11vnc.pp
+++ b/manifests/x11vnc.pp
@@ -70,12 +70,12 @@ class display::x11vnc (
 
   if ($refresh_systemd) {
     exec { 'refresh_systemd x11vnc':
-      subscribe => File['x11vnc-init'],
-      command => 'systemctl daemon-reload',
+      subscribe   => File['x11vnc-init'],
+      command     => 'systemctl daemon-reload',
       refreshonly => true,
-      path   => $::path,
-    } ~>
-    Service['x11vnc']
+      path        => $::path,
+    }
+    ~> Service['x11vnc']
   }
 
   service { 'x11vnc':

--- a/manifests/x11vnc.pp
+++ b/manifests/x11vnc.pp
@@ -75,7 +75,7 @@ class display::x11vnc (
       refreshonly => true,
       path   => $::path,
     } ~>
-    Service ['x11vnc']
+    Service['x11vnc']
   }
 
   service { 'x11vnc':

--- a/manifests/xvfb.pp
+++ b/manifests/xvfb.pp
@@ -92,7 +92,7 @@ class display::xvfb (
       refreshonly => true,
       path   => $::path,
     } ~>
-    Service ['xvfb']
+    Service['xvfb']
   }
 
   service { 'xvfb':

--- a/manifests/xvfb.pp
+++ b/manifests/xvfb.pp
@@ -87,12 +87,12 @@ class display::xvfb (
 
   if ($refresh_systemd) {
     exec { 'refresh_systemd xvfb':
-      subscribe => File['xvfb-init'],
-      command => 'systemctl daemon-reload',
+      subscribe   => File['xvfb-init'],
+      command     => 'systemctl daemon-reload',
       refreshonly => true,
-      path   => $::path,
-    } ~>
-    Service['xvfb']
+      path        => $::path,
+    }
+    ~> Service['xvfb']
   }
 
   service { 'xvfb':
@@ -101,5 +101,4 @@ class display::xvfb (
     enable    => true,
     subscribe => File['xvfb-init'],
   }
-  
 }

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.1.1 <3.0.0"
+      "version_requirement": ">= 1.1.1"
     },
     { "name": "puppetlabs/stdlib",
       "version_requirement":">= 4.9.0 <5.0.0"


### PR DESCRIPTION
Hello,
I've seend a stupid syntax error that prevents Puppet 5.5 from successful run.

Previously i've seen errors:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: No title provided and "Service[]" is not a valid resource reference on node XXX
```